### PR TITLE
fix: install instructions main

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 ```lua
 {
   'saghen/blink.indent',
+  main = 'blink.indent',
   opts = {
     -- or disable with `vim.g.indent_guide = false` (global) or `vim.b.indent_guide = false` (per-buffer)
     blocked = {


### PR DESCRIPTION
Lazy manager tries to require `blink` which does not work because module is `blink.indent`, so fixing that here