### PR TITLE
fix: default to space if no listchars.space is set

### DIFF
--- a/lua/blink/indent/static.lua
+++ b/lua/blink/indent/static.lua
@@ -7,7 +7,7 @@ M.draw = function(ns, indent_levels, bufnr, range)
   vim.api.nvim_buf_clear_namespace(bufnr, ns, 0, -1)
 
   local shiftwidth = utils.get_shiftwidth(bufnr)
-  local space = vim.opt.listchars:get().space
+  local space = vim.opt.listchars:get().space or ' '
   local symbol = config.static.char .. string.rep(space, shiftwidth - 1)
 
   -- add the new indents


### PR DESCRIPTION
Otherwise, errors will be thrown on each redraw when no space character is specified in `listchars`.