### PR TITLE
docs: missing comma in `setup()` code block

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ vim.pack.add({ 'saghen/blink.indent' })
 
 ## Options
 
-Note that calling `setup` is optional, as the plugin will automatically initialize with the default configuration.
+Note that calling `setup()` is optional, as the plugin will automatically initialize with the default configuration.
 
 Disable with `vim.g.indent_guide = false` (global) or `vim.b[bufnr].indent_guide = false` (per-buffer). Some filetypes and buftypes are disabled by default, see below. You may also create a keymap to toggle visibility like so:
 


### PR DESCRIPTION
## Description

The `require('blink.indent').setup(...)` section had a missing comma in `README.md`. Fixed it promptly.

Also added brackets for ``` `setup()` ``` .