### PR TITLE
fix: remove debug scope range statement

### DIFF
--- a/lua/blink/indent/motion.lua
+++ b/lua/blink/indent/motion.lua
@@ -44,7 +44,6 @@ function M.operator(side, add_to_jumplist)
 
     -- Make sequence of jumps
     for _ = 1, count do
-      vim.print(scope_range)
       move_cursor(scope_range, side)
 
       indent_level, scope_range = parser.get_scope()


### PR DESCRIPTION
Accidentally added in 2227b3526bf34eb71601cf817cfb861a51abcf50.