### PR TITLE
feat: add support for breakindent

### DIFF
--- a/lua/blink/indent/init.lua
+++ b/lua/blink/indent/init.lua
@@ -95,7 +95,7 @@ M.draw = function(winnr, bufnr, force)
 
   -- static
   if config.static.enabled and not is_cached then
-    static.draw(bufnr, config.static.ns, indent_levels, range)
+    static.draw(winnr, bufnr, config.static.ns, indent_levels, range)
   elseif not config.static.enabled then
     vim.api.nvim_buf_clear_namespace(bufnr, config.static.ns, 0, -1)
   end
@@ -103,7 +103,7 @@ M.draw = function(winnr, bufnr, force)
   -- scope
   if config.scope.enabled then
     local scope_range = parser.get_scope_partial(bufnr, winnr, indent_levels, range)
-    scope.draw(bufnr, config.scope.ns, indent_levels, scope_range, range)
+    scope.draw(winnr, bufnr, config.scope.ns, indent_levels, scope_range, range)
   elseif not config.scope.enabled then
     vim.api.nvim_buf_clear_namespace(bufnr, config.scope.ns, 0, -1)
   end

--- a/lua/blink/indent/scope.lua
+++ b/lua/blink/indent/scope.lua
@@ -5,12 +5,13 @@ local utils = require('blink.indent.utils')
 
 M.cache = utils.make_buffer_cache()
 
+--- @param winnr integer
 --- @param bufnr integer
 --- @param ns integer
 --- @param indent_levels table<integer, integer>
 --- @param scope_range blink.indent.ScopeRange
 --- @param range blink.indent.ParseRange
-function M.draw(bufnr, ns, indent_levels, scope_range, range)
+function M.draw(winnr, bufnr, ns, indent_levels, scope_range, range)
   local cache_entry = M.cache[bufnr]
   if
     cache_entry ~= nil
@@ -36,6 +37,7 @@ function M.draw(bufnr, ns, indent_levels, scope_range, range)
   local win_col = (indent_level - 1) * utils.get_shiftwidth(bufnr) - range.horizontal_offset
   if win_col < 0 then return end
 
+  local breakindent = utils.get_breakindent(winnr)
   local symbol = config.scope.char
   local hl_group = utils.get_rainbow_hl(indent_level - 1, config.scope.highlights)
 
@@ -44,6 +46,7 @@ function M.draw(bufnr, ns, indent_levels, scope_range, range)
       virt_text = { { symbol, hl_group } },
       virt_text_pos = 'overlay',
       virt_text_win_col = win_col,
+      virt_text_repeat_linebreak = breakindent,
       hl_mode = 'combine',
       priority = config.scope.priority,
     })

--- a/lua/blink/indent/static.lua
+++ b/lua/blink/indent/static.lua
@@ -6,11 +6,12 @@ local utils = require('blink.indent.utils')
 --- @type table<integer, { indent_levels: table<integer, integer>, extmark_ids: table<integer, integer>, changedtick: integer }>
 M.cache = utils.make_buffer_cache()
 
+--- @param winnr integer
 --- @param bufnr integer
 --- @param ns integer
 --- @param indent_levels table<integer, integer>
 --- @param range { start_line: integer, end_line: integer, horizontal_offset: integer }
-function M.draw(bufnr, ns, indent_levels, range)
+function M.draw(winnr, bufnr, ns, indent_levels, range)
   -- cache the indent levels to avoid unnecessary extmark draws
   if not M.cache[bufnr] then
     vim.api.nvim_buf_clear_namespace(bufnr, ns, 0, -1)
@@ -21,6 +22,7 @@ function M.draw(bufnr, ns, indent_levels, range)
   end
   local cache_entry = M.cache[bufnr]
 
+  local breakindent = utils.get_breakindent(winnr)
   local shiftwidth = utils.get_shiftwidth(bufnr)
   local space = vim.opt.listchars:get().space or ' '
   local symbol = config.static.char .. space:rep(shiftwidth - 1)
@@ -48,6 +50,7 @@ function M.draw(bufnr, ns, indent_levels, range)
         id = cache_entry.extmark_ids[line_number],
         virt_text = { { virt_text, hl_group } },
         virt_text_pos = 'overlay',
+        virt_text_repeat_linebreak = breakindent,
         hl_mode = 'combine',
         priority = config.static.priority,
       })

--- a/lua/blink/indent/utils.lua
+++ b/lua/blink/indent/utils.lua
@@ -1,10 +1,19 @@
 local M = {}
 
 --- @param bufnr integer
+--- @return integer
 function M.get_shiftwidth(bufnr)
   local shiftwidth = vim.bo[bufnr].shiftwidth
   if shiftwidth == 0 then shiftwidth = vim.bo[bufnr].tabstop end
   return math.max(shiftwidth, 2)
+end
+
+--- @param winnr integer
+--- @return boolean
+function M.get_breakindent(winnr)
+  local breakindent = vim.wo[winnr].breakindent
+  if breakindent == nil then breakindent = vim.o.breakindent end
+  return breakindent
 end
 
 --- @param bufnr integer

--- a/plugin/blink-indent.lua
+++ b/plugin/blink-indent.lua
@@ -35,7 +35,7 @@ vim.api.nvim_create_autocmd({ 'CursorMoved', 'CursorMovedI' }, {
 })
 vim.api.nvim_create_autocmd('OptionSet', {
   group = augroup,
-  pattern = { 'shiftwidth', 'listchars', 'tabstop' },
+  pattern = { 'shiftwidth', 'listchars', 'tabstop', 'breakindent' },
   callback = function() indent.draw_all(true) end,
 })
 


### PR DESCRIPTION
For some reason, the repeated extmark replaces the background of the cursor line.

<img width="1258" height="103" alt="image" src="https://github.com/user-attachments/assets/a65a9e1d-3f50-4fff-a2cb-6c9b0116b089" />

Closes #34 