### PR TITLE
fix: clamp scope start line

### DIFF
--- a/lua/blink/indent/parser/scope.lua
+++ b/lua/blink/indent/parser/scope.lua
@@ -16,6 +16,7 @@ local M = {}
 function M.get_scope_partial(bufnr, winnr, indent_levels, range)
   local cursor_line = vim.api.nvim_win_get_cursor(winnr)[1]
   local scope_search_start_line, scope_indent_level = M.get_scope_start(bufnr, cursor_line, utils.get_shiftwidth(bufnr))
+  scope_search_start_line = math.min(math.max(scope_search_start_line, range.start_line), range.end_line)
 
   -- move up and down to find the scope
   local scope_start_line = scope_search_start_line


### PR DESCRIPTION
problem:
indent_levels in get_scope_partial includes only the indent levels for the viewport of the window, if the cursor is out of the viewport, trying to access its indent level in indent_levels results in nil, when you try to use the nil value error happens. this happens in #36 . i can reproduce it with vim.opt.cursorline = true, vim.opt.splitkeep = "screen", go to bottom of the file, open a split below, you can see that the cursorline doesnt show in the original file's viewport.

this fix just clamps scope_search_start_line to the parsed viewport range. This prevents indent_levels lookups from going out of bounds fixing the nil comparison crash.